### PR TITLE
set_next_event based on switch time

### DIFF
--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,6 +1,7 @@
 import pytest
 from freezegun import freeze_time
 from aiohttp import ClientSession
+import datetime as dt
 from pyaffalddk import GarbageCollection, NAME_LIST, api, const
 from .data import const_tests
 from pathlib import Path
@@ -264,6 +265,26 @@ async def test_smoketest(capsys, monkeypatch, update=False):
                     print(data)
                     print(smokecompare[name])
                 assert smokecompare[name] == data
+
+
+@pytest.mark.asyncio
+@freeze_time("2025-05-22 12:30:00")
+async def test_switch_next(capsys, monkeypatch):
+    with capsys.disabled():
+        async with ClientSession() as session:
+            gc = GarbageCollection('Viborg', session=session, fail=True)
+            address = await gc.get_address_id('8800', 'Prinsens Alle', '5')
+
+            async def get_data(*args, **kwargs):
+                return revas_data
+            monkeypatch.setattr(gc._api, "get_garbage_data", get_data)
+
+            pickups = await gc.get_pickup_data(address.address_id)
+            assert pickups['next_pickup'].date == dt.date(2025, 5, 22)
+
+            gc.set_switch_time(12, 0)
+            pickups = await gc.get_pickup_data(address.address_id)
+            assert pickups['next_pickup'].date == dt.date(2025, 6, 4)
 
 
 def test_type_from_material_cleaning(capsys, monkeypatch):


### PR DESCRIPTION
To fix https://github.com/briis/pyaffalddk/issues/41 I have here suggested the following changes:

1. We will only fetch pickup data online ones per day, unless no pickup data was retrieved, then it will still try online also next time. This makes sure that we from HA can call the update as often as we want without putting unneeded stress on the online API's
2. I have added a new attribute to `GarbageCollection()` named `switch_time`. It is for default set to 15:00, but it can be set to any time with the new `set_switch_time(hours, minutes)` function - should we also add it as a init arguments for `GarbageCollection()` ? If the current time is later than the `switch_time` then the `next event` will always be later than today.

Please have a look at the `test_switch_next` test, where I get the next_event of the same day at the test freeze time of  "2025-05-22 12:30:00", but when setting the switch_time to before 12:30, the next event is now on "2025-6-4". Also for the second call there is no re-fetching of data (not part of the test asserts, but I checked...)

